### PR TITLE
Fix unnecessary Statefull components and PropType validations

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import Header from './components/header';
 import Article from './components/article';
@@ -53,11 +53,11 @@ Card.defaultProps = {
 };
 
 Card.propTypes = {
-  src: React.PropTypes.string,
-  titleSmallWord: React.PropTypes.string,
-  titleBigWord: React.PropTypes.string,
-  color: React.PropTypes.string,
-  text: React.PropTypes.string
+  src: PropTypes.string,
+  titleSmallWord: PropTypes.string,
+  titleBigWord: PropTypes.string,
+  color: PropTypes.string,
+  text: PropTypes.string
 };
 
 export default Card;

--- a/src/app.js
+++ b/src/app.js
@@ -3,9 +3,7 @@ import { StyleSheet, css } from 'aphrodite';
 import Header from './components/header';
 import Article from './components/article';
 
-
 const styles = StyleSheet.create({
-
   card: {
     margin: '0',
     padding: '0',
@@ -15,7 +13,6 @@ const styles = StyleSheet.create({
     height: 'auto',
     backgroundColor: '#f4f4f4',
     transition: 'all .3s ease'
-    // transition: 'box-shadow .3s ease'
   },
 
   hover: {
@@ -26,30 +23,25 @@ const styles = StyleSheet.create({
   }
 });
 
-class Card extends React.Component {
+const Card = ({ src, titleSmallWord, titleBigWord, color, text, children}) => (
+  <div className={css(styles.card, styles.hover)}>
+    <Header
+      src={src}
+      titleSmallWord={titleSmallWord}
+      titleBigWord={titleBigWord}
+      color={color} />
 
-  render() {
-    return (
-      <main className={css(styles.card, styles.hover)}>
-        <Header
-          src={this.props.src}
-          titleSmallWord={this.props.titleSmallWord}
-          titleBigWord={this.props.titleBigWord}
-          color={this.props.color} />
-
-        <Article
-          text={this.props.children} />
-      </main>
-    );
-  }
-}
+    <Article
+      text={children} />
+  </div>
+)
 
 Card.defaultProps = {
-    src: 'https://avatars.githubusercontent.com/u/9022134?v=3',
-    titleSmallWord: 'Hello',
-    titleBigWord: 'World',
-    color: 'purple',
-    text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+  src: 'https://avatars.githubusercontent.com/u/9022134?v=3',
+  titleSmallWord: 'Hello',
+  titleBigWord: 'World',
+  color: 'purple',
+  text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 };
 
 Card.propTypes = {
@@ -57,7 +49,8 @@ Card.propTypes = {
   titleSmallWord: PropTypes.string,
   titleBigWord: PropTypes.string,
   color: PropTypes.string,
-  text: PropTypes.string
+  text: PropTypes.string,
+  children: PropTypes.node.isRequired
 };
 
 export default Card;

--- a/src/components/article.js
+++ b/src/components/article.js
@@ -12,16 +12,11 @@ const styles = StyleSheet.create({
   }
 })
 
-
-class Article extends React.Component {
-  render() {
-    return (
-      <article className={css(styles.card__article)}>
-        <p>{this.props.text}</p>
-      </article>
-    );
-  }
-}
+const Article = ({ text }) => (
+  <article className={css(styles.card__article)}>
+    <p>{text}</p>
+  </article>
+)
 
 Article.propTypes = {
   text: PropTypes.string.isRequired

--- a/src/components/article.js
+++ b/src/components/article.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 
 const styles = StyleSheet.create({
@@ -21,6 +21,10 @@ class Article extends React.Component {
       </article>
     );
   }
+}
+
+Article.propTypes = {
+  text: PropTypes.string.isRequired
 }
 
 export default Article;

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 
 const styles = StyleSheet.create({
@@ -28,7 +28,6 @@ const styles = StyleSheet.create({
     height: '300px',
     zIndex: '0'
   },
-
 
   title: {
     margin: '0',
@@ -60,30 +59,44 @@ const styles = StyleSheet.create({
 })
 
 
-class Header extends React.Component {
-  render() {
-    const color = StyleSheet.create({
-      overlay: {
-        position: 'absolute',
-        width: '100%',
-        height: '300px',
-        backgroundColor: this.props.color,
-        opacity: '.5',
-        zIndex: '1'
-      }
-    });
-    return (
-      <header className={css(styles.card__header)}>
-        <span className={css(styles.tooltip)}></span>
-        <div className={css(color.overlay)}></div>
-        <img alt={`${this.props.titleSmallWord} ${this.props.titleBigWord}`} className={css(styles['card__header--image'])} src={this.props.src} />
-        <h1 className={css(styles.title)}>
-          <small className={css(styles.small)}>{this.props.titleSmallWord},</small>
-          {this.props.titleBigWord}
-        </h1>
-      </header>
-    );
-  }
+
+const Header = ({ titleBigWord, titleSmallWord, src, color }) => {
+  const background = StyleSheet.create({
+    overlay: {
+      position: 'absolute',
+      width: '100%',
+      height: '300px',
+      backgroundColor: color,
+      opacity: '.5',
+      zIndex: '1'
+    }
+  })
+
+  return (
+    <header className={css(styles.card__header)}>
+      <span className={css(styles.tooltip)} />
+
+      <div className={css(background.overlay)} />
+
+      <img
+        alt={`${titleSmallWord} ${titleBigWord}`}
+        className={css(styles['card__header--image'])}
+        src={src}
+      />
+
+      <h1 className={css(styles.title)}>
+        <small className={css(styles.small)}>{titleSmallWord},</small>
+        {titleBigWord}
+      </h1>
+    </header>
+  )
+}
+
+Header.propTypes = {
+  titleBigWord: PropTypes.string.isRequired,
+  titleSmallWord: PropTypes.string.isRequired,
+  src: PropTypes.string.isRequired,
+  color: PropTypes.string.isRequired
 }
 
 export default Header;

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,32 @@
 import React from 'react';
-import ReactDom from 'react-dom';
+import { render } from 'react-dom';
 import Card from './app.js';
 
+const App = () => (
+  <div className='container'>
+    <Card
+      src='http://www.media.inaf.it/wp-content/uploads/2014/02/Einstein_laughing.jpeg'
+      titleSmallWord='Albert'
+      titleBigWord='Einstein'
+      color='tomato'>
+      Albert Einstein was a German-born theoretical physicist. He developed the general theory of relativity, one of the two pillars of modern physics (alongside quantum mechanics). Einstein's work is also known for its influence on the philosophy of science.
+    </Card>
 
-class App extends React.Component {
+    <Card
+      src='https://upload.wikimedia.org/wikipedia/commons/b/b9/Steve_Jobs_Headshot_2010-CROP.jpg'
+      titleSmallWord='Steve'
+      titleBigWord='Jobs'
+      color='yellow'>
+      Steven Paul 'Steve' Jobs was an American information technology entrepreneur and inventor. He was the co-founder, chairman, and chief executive officer (CEO) of Apple Inc.; CEO and majority shareholder of Pixar Animation Studios; a member of The Walt Disney Company's board of directors following its acquisition of Pixar; and founder, chairman, and CEO of NeXT Inc.
+    </Card>
 
-  render() {
-    return (
-      <div className='container'>
-        <Card
-          src='http://www.media.inaf.it/wp-content/uploads/2014/02/Einstein_laughing.jpeg'
-          titleSmallWord='Albert'
-          titleBigWord='Einstein'
-          color='tomato'>
-          Albert Einstein was a German-born theoretical physicist. He developed the general theory of relativity, one of the two pillars of modern physics (alongside quantum mechanics). Einstein's work is also known for its influence on the philosophy of science.
-        </Card>
+    <Card
+      src='http://images.uncyc.org/pt/0/04/Linus_Torvalds.jpg'
+      titleSmallWord='Linus'
+      titleBigWord='Torvalds'>
+      Linus Benedict Torvalds, born December 28, 1969, is a Finnish software engineer, American naturalized, who is the creator and, for a long time, principal developer, of the Linux kernel, which became the kernel for operating systems (and many distributions of each) such as GNU and years later Android and Chrome OS. He also created the distributed revision control system git.
+    </Card>
+  </div>
+)
 
-        <Card
-          src='https://upload.wikimedia.org/wikipedia/commons/b/b9/Steve_Jobs_Headshot_2010-CROP.jpg'
-          titleSmallWord='Steve'
-          titleBigWord='Jobs'
-          color='yellow'>
-          Steven Paul 'Steve' Jobs was an American information technology entrepreneur and inventor. He was the co-founder, chairman, and chief executive officer (CEO) of Apple Inc.; CEO and majority shareholder of Pixar Animation Studios; a member of The Walt Disney Company's board of directors following its acquisition of Pixar; and founder, chairman, and CEO of NeXT Inc.
-        </Card>
-
-        <Card
-          src='http://images.uncyc.org/pt/0/04/Linus_Torvalds.jpg'
-          titleSmallWord='Linus'
-          titleBigWord='Torvalds'>
-          Linus Benedict Torvalds, born December 28, 1969, is a Finnish software engineer, American naturalized, who is the creator and, for a long time, principal developer, of the Linux kernel, which became the kernel for operating systems (and many distributions of each) such as GNU and years later Android and Chrome OS. He also created the distributed revision control system git.
-        </Card>
-      </div>
-    )
-  }
-}
-
-ReactDom.render(<App /> , document.getElementById('App'));
+render(<App /> , document.getElementById('App'));


### PR DESCRIPTION
Todos os componentes não tinham estado local e nem algum método do lifecycle do React. Não havia razões para extender o Component do React. Nesse caso os pure components são mais limpos e fáceis de entender.

Além disso ajustei algumas validações ausentes de PropTypes.

Outro detalhe importante é que a tag main deve ser usada para englobar o conteúdo principal do site e apenas uma vez. https://developer.mozilla.org/en/docs/Web/HTML/Element/main